### PR TITLE
Ensure dependencies of mainRows are added in deterministic order

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "flush-write-stream": "^1.0.2",
     "labeled-stream-splicer": "^2.0.0",
     "object-delete-value": "^1.0.0",
-    "object-values": "^1.0.0",
     "outpipe": "^1.1.1",
     "resolve": "^1.5.0",
     "run-parallel": "^1.1.6",

--- a/plugin.js
+++ b/plugin.js
@@ -10,7 +10,6 @@ var splicer = require('labeled-stream-splicer')
 var pack = require('browser-pack')
 var runParallel = require('run-parallel')
 var deleteValue = require('object-delete-value')
-var values = require('object-values')
 var isRequire = require('estree-is-require')
 var outpipe = require('outpipe')
 var dash = require('dash-ast')
@@ -309,10 +308,12 @@ function createSplitter (b, opts) {
   }
 
   function gatherDependencyIds (row, arr) {
-    var deps = values(row.deps)
+    var sortedDeps = Object.keys(row.deps).sort().map(function (key) {
+      return row.deps[key]
+    })
     arr = arr || []
 
-    deps.forEach(function (id) {
+    sortedDeps.forEach(function (id) {
       var dep = rowsById[id]
       if (!dep || arr.indexOf(dep.id) !== -1) {
         return


### PR DESCRIPTION
The `row.deps` object contains dependency IDs in the order that they were loaded in by module-deps. That's done concurrently so the order isn't always the same. This patch sorts the list of dependencies before adding them to the bundle.