### PR TITLE
Option to load relative to parent script

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -32,7 +32,7 @@ function load (index, cb) {
   }
 
   // get path relative to current script
-  var url = (new URL(load.b[index], scriptSrc)).href
+  var url = (new URL(load.b[index], scriptUrl)).href
 
   // TODO throw an error if we don't have the url
 

--- a/browser.js
+++ b/browser.js
@@ -4,6 +4,8 @@ var cache = {}
 // multiple times simultaneously.
 var receivers = {}
 
+var scriptUrl = document.currentScript.src
+
 // Attach a promise to a callback, that is settled when the callback is called.
 function promisify (cb) {
   var res
@@ -30,7 +32,7 @@ function load (index, cb) {
   }
 
   // get path relative to current script
-  var url = (new URL(load.b[index], document.currentScript.src)).href
+  var url = (new URL(load.b[index], scriptSrc)).href
 
   // TODO throw an error if we don't have the url
 

--- a/browser.js
+++ b/browser.js
@@ -29,7 +29,9 @@ function load (index, cb) {
     return cb.p
   }
 
-  var url = load.b[index]
+  // get path relative to current script
+  var url = (new URL(load.b[index], document.currentScript.src)).href
+
   // TODO throw an error if we don't have the url
 
   // Combine callbacks if another one was already registered.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "split-require",
   "description": "CommonJS-first bundle splitting, for browserify",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "bugs": {
     "url": "https://github.com/goto-bus-stop/split-require/issues"
   },


### PR DESCRIPTION
We had setup where we serve scripts from CDN, in this process we realized that it was not possible to load chunks from remote URL